### PR TITLE
bigger logo and navbar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
           <div class="banner-image">
             <nav class="navbar navbar-dark transparent navbar-expand-sm fixed-top">
               <a class="navbar-brand" href="{{ 'index.html' | relative_url }}">
-                <img src="{{ '/assets/images/icons/mm_word_logo.png' | relative_url }}" height="25" alt="">
+                <img src="{{ '/assets/images/icons/mm_word_logo.png' | relative_url }}" height="35" alt="">
               </a>
               <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/assets/css/mmsite.scss
+++ b/assets/css/mmsite.scss
@@ -83,6 +83,10 @@ a:active {
   background-image: linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75));
 }
 
+.navbar a{
+  font-size: 1.1em;
+}
+
 /********************************/
 /** Adjustments to containers  **/
 /********************************/


### PR DESCRIPTION
To address Issue #3. Its impossible to make the logo size in a navbar responsive to changes in size, so I just increased the height of the logo to 35px for a taller navbar. I increased the text size of the links a little as well to compensate. Here is a screenshot:

<img width="1112" alt="screen shot 2018-09-18 at 5 05 59 pm" src="https://user-images.githubusercontent.com/16107446/45723344-a6d70300-bb65-11e8-8a35-861d7b58a9b4.png">
