### PR TITLE
updated slack invite link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,9 +21,9 @@
   <link rel="icon" type="image/vnd.microsoft.icon" sizes="32x32 48x48" href="/assets/images/icons/favicon.ico">
   <link rel="icon" sizes="128x128" href="favicon.icns">
   <link rel="icon" href="/assets/images/icons/favicon.png" type="image/x-icon">
-  
+
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha256-Md8eaeo67OiouuXAi8t/Xpd8t2+IaJezATVTWbZqSOw= sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB sha512-iqRdf+0KMFmNZgdsA+8bz1MWIIXQBUCavPYVSVI83fcVfH2Y2PnNooLN04bgTNoUiQvIzidiIHJAcIP/uAEV9w==" crossorigin="anonymous">
-  <link href="{{ '/assets/css/mmsite.css' | relative_url }}" rel="stylesheet"> 
+  <link href="{{ '/assets/css/mmsite.css' | relative_url }}" rel="stylesheet">
   <link href="{{ '/assets/css/syntax.css' | relative_url }}"rel="stylesheet" >
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
@@ -55,14 +55,14 @@
                   <div class="tooltip-switch">
                     <button id="switch-light" class="choose-light"></button>
                     <span class="tooltiptext">light theme</span>
-                  </div>         
-                  <div class="tooltip-switch">     
+                  </div>
+                  <div class="tooltip-switch">
                     <button id="switch-dark" class="choose-dark"></button>
                     <span class="tooltiptext">dark theme</span>
                   </div>
                   <a class="nav-item nav-link active" href="https://www.facebook.com/MegaMek"><i class="fa fa-facebook"></i></a>
                   <a class="nav-item nav-link active" href="https://twitter.com/MegaMekTeam"><i class="fa fa-twitter"></i></a>
-                  <a class="nav-item nav-link active" href="http://megamek.org:3000"><i class="fa fa-slack"></i></a>
+                  <a class="nav-item nav-link active" href="https://join.slack.com/t/megamek-public/shared_invite/enQtMzU1MTE1MDA2MTM0LWQ1YTMwN2Y5NTY0MDc4ZmU0NDNkNzE3ZDY0YWE1ZjE3MzJmYjdjODc4NTI3YzhjOGE0YjI4NWRmMjFiY2ZlZGY"><i class="fa fa-slack"></i></a>
                   <a class="nav-item nav-link active" href="https://www.github.com/megamek"><i class="fa fa-github"></i></a>
                 </ul>
               </div>


### PR DESCRIPTION
I am changing the slack invite link on the new megamek site to just use the standard invite link provided by slack. This is set to have no expiration date and so should work without extra fiddling. 