### PR TITLE
Remove Google Analytics

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -61,11 +61,3 @@
     });
   });
 </script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-146310794-1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-146310794-1');
-</script>


### PR DESCRIPTION
We really don't need to be tracking anything and this also brings us within GDPR compliance due to tracking cookies.