### PR TITLE
Add missing "I want to help" wiki page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.7-alpine
+WORKDIR /app
+COPY . ./
+RUN apk update
+RUN apk add --no-cache build-base gcc cmake git
+RUN gem update --system && gem update bundler && gem install bundler jekyll:3.9.3
+RUN echo "$PWD"
+RUN bundle add webrick
+RUN bundle install && bundle update
+RUN bundle exec jekyll --version
+EXPOSE 4000 80
+CMD bundle exec jekyll serve --watch --incremental --host 0.0.0.0 -P 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM ruby:2.7-alpine
-WORKDIR /app
-COPY . ./
 RUN apk update
 RUN apk add --no-cache build-base gcc cmake git
 RUN gem update --system && gem update bundler && gem install bundler jekyll:3.9.3
-RUN echo "$PWD"
+WORKDIR /app
+COPY . ./
 RUN bundle add webrick
 RUN bundle install && bundle update
-RUN bundle exec jekyll --version
-EXPOSE 4000 80
-CMD bundle exec jekyll serve --watch --incremental --host 0.0.0.0 -P 4000
+CMD bundle exec jekyll serve --watch --incremental --force_polling --host 0.0.0.0 -P 4000

--- a/README.md
+++ b/README.md
@@ -96,12 +96,20 @@ example, for a PDF:
 
 ## Development
 
-To test out changes to a local repository, you need to install [Jekyll](https://jekyllrb.com/). Then
+To test out changes to a local repository, you need to install [Docker](https://www.docker.com/). Then
 from the command line within the repository run:
 
 ```Shell
-jekyll serve
+docker build -t jekyll .
 ```
+to build a local Docker image containing all the tools needed to compile and host the site.
+Once the image is built, just use:
+
+```
+docker run -it --rm -p "4000:4000" jekyll
+```
+
+to start the local site host.
 
 The website should then be viewable at [localhost:4000](http://localhost:4000).
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker build -t jekyll .
 to build a local Docker image containing all the tools needed to compile and host the site.
 Once the image is built, just use:
 
-```
+```Shell
 docker run -it --rm -p "4000:4000" jekyll
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ to build a local Docker image containing all the tools needed to compile and hos
 Once the image is built, just use:
 
 ```Shell
-docker run -it --rm -p "4000:4000" jekyll
+docker run -it --rm -v ${PWD}:${PWD} -w ${PWD} -p "4000:4000" jekyll
 ```
 
 to start the local site host.

--- a/_posts/2022-02-18-New Development Release v0.49.7.md
+++ b/_posts/2022-02-18-New Development Release v0.49.7.md
@@ -115,7 +115,7 @@ UlyssesSockdrawer has been running a popular Solaris VII campaign on our Discord
 
 ### Contributing
 
-[Please check out this document for contributing to the suite](https://megamek.org/wiki/I-want-to-help)
+[Please check out this document for contributing to the suite]({{ site.baseurl }} {% link wiki/i_want_to_help.md %})
 
 ### Updating Your Campaign:
 

--- a/_posts/2022-05-27-New Development Release v0.49.8.md
+++ b/_posts/2022-05-27-New Development Release v0.49.8.md
@@ -92,7 +92,7 @@ We thank everyone who's been part of this community and for those that haven't p
 
 ## Contributing
 
-[Please](https://megamek.org/wiki/I-want-to-help) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
+[Please]({{ site.baseurl }} {% link wiki/i_want_to_help.md %}) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
 
 ## Updating Your Campaign
 

--- a/_posts/2022-09-07-New Development Release v0.49.9.md
+++ b/_posts/2022-09-07-New Development Release v0.49.9.md
@@ -90,7 +90,7 @@ We thank everyone who's been part of this community and for those that haven't p
 
 ## Contributing
 
-[Please](https://megamek.org/wiki/I-want-to-help) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
+[Please]({{ site.baseurl }} {% link wiki/i_want_to_help.md %}) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
 
 ## Updating Your Campaign
 

--- a/_posts/2022-09-12-New Development Release v0.49.10.md
+++ b/_posts/2022-09-12-New Development Release v0.49.10.md
@@ -54,7 +54,7 @@ We thank everyone who's been part of this community and for those that haven't p
 
 ## Contributing
 
-[Please](https://megamek.org/wiki/I-want-to-help) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
+[Please]({{ site.baseurl }} {% link wiki/i_want_to_help.md %}) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
 
 ## Updating Your Campaign
 

--- a/_posts/2022-12-22-New Development Release v0.49.11.md
+++ b/_posts/2022-12-22-New Development Release v0.49.11.md
@@ -74,7 +74,7 @@ We are also happy to announce we have an [official MegaMek Discord](https://disc
 
 ## Contributing
 
-[Please](https://megamek.org/wiki/I-want-to-help) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
+[Please]({{ site.baseurl }} {% link wiki/i_want_to_help.md %}) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
 
 ## Updating Your Campaign
 

--- a/_posts/2023-03-04-New Development Release v0.49.12.md
+++ b/_posts/2023-03-04-New Development Release v0.49.12.md
@@ -70,7 +70,7 @@ We are also happy to announce we have an [official MegaMek Discord](https://disc
 
 ## Contributing
 
-[Please](https://megamek.org/wiki/I-want-to-help) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
+[Please]({{ site.baseurl }} {% link wiki/i_want_to_help.md %}) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
 
 ## Updating Your Campaign
 

--- a/_posts/2023-05-24-New Development Release v0.49.13.md
+++ b/_posts/2023-05-24-New Development Release v0.49.13.md
@@ -81,7 +81,7 @@ We are also happy to announce we have an [official MegaMek Discord](https://disc
 
 #### Contributing
 
-[Please](https://megamek.org/wiki/I-want-to-help) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
+[Please]({{ site.baseurl }} {% link wiki/i_want_to_help.md %}) check out this document for contributing to the suite. Deadborder has us covered from land unit sprites and camos. But we desperately need sprites for aerospace units.
 
 #### Updating Your Campaign
 

--- a/wiki/i_want_to_help.md
+++ b/wiki/i_want_to_help.md
@@ -1,0 +1,8 @@
+---
+layout: info_page
+title: I Want To Help
+---
+
+### Contributing to MegaMek
+
+Please see the [MegaMek github wiki](https://github.com/MegaMek/megamek/wiki/I-want-to-help) for more information on contributing to the project.


### PR DESCRIPTION
Fixes #80 

This commit also includes:
1. a Dockerfile that can be used to set up local Jekyll hosting without
   faffing about with Ruby, Jekyll, Bundle, etc.
2. Instructions on how to use the docker container for local hosting
3. Updated links in the recent release posts making links to the missing
   "I want to help" wiki page work both locally and once deployed.