### PR TITLE
Prepare for the default branch rename to main

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,9 +7,11 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch. Both names are listed while the
+  # default branch is renamed from master to main, so the site keeps building
+  # either side of the rename; master can be dropped once it is done.
   push:
-    branches: ["master"]
+    branches: ["master", "main"]
 
   # Runs after the daily download snapshot commits new data. The snapshot bot
   # pushes with GITHUB_TOKEN, which does not trigger the push event above, so

--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ The website should then be viewable at [localhost:4000](http://localhost:4000).
 ### PR and Commit Policies
 
 For minor spelling/grammatical corrections or basic updates to content (e.g. updating links), devs
-with access may push directly to the master branch. For substantial content revisions, new content,
+with access may push directly to the main branch. For substantial content revisions, new content,
 or website design changes, a pull request should be made and approved by another dev.


### PR DESCRIPTION
## Why

This repository is the only one in the org still on `master`; megamek, mm-data, megameklab and MekHQ are all on `main`. This is the preparation step so the rename can happen without taking the site down.

## The hazard this avoids

megamek.org is built by `.github/workflows/jekyll.yml`, and its trigger names the branch literally:

```yaml
push:
  branches: ["master"]
```

Renaming the default branch without touching that line means pushes to `main` match nothing, the deploy workflow never runs, and the live site silently freezes at its current content. There is no error anywhere obvious - the site simply stops updating.

## Changes

1. `.github/workflows/jekyll.yml` - the push trigger accepts `["master", "main"]`, so the site builds either side of the rename. `master` can be dropped once the rename is done.
2. `README.md` - the PR and Commit Policies section pointed contributors at "the master branch".

`snapshot-downloads.yml` needs no change: it is cron-driven with no branch filter and commits to whatever the default branch is.

## After this merges

1. Rename the branch on GitHub (Settings -> Branches, or the API). GitHub redirects old links and retargets any open PRs.
2. Every dev updates their clone:

```bash
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

3. Optionally drop `"master"` from the workflow trigger.

## Testing

Not something a build can prove. The workflow file is valid YAML and the trigger is a superset of what it was, so the current behaviour is unchanged until the rename happens.