### PR TITLE
Drop master from the Pages deploy trigger

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,11 +7,9 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  # Runs on pushes targeting the default branch. Both names are listed while the
-  # default branch is renamed from master to main, so the site keeps building
-  # either side of the rename; master can be dropped once it is done.
+  # Runs on pushes targeting the default branch
   push:
-    branches: ["master", "main"]
+    branches: ["main"]
 
   # Runs after the daily download snapshot commits new data. The snapshot bot
   # pushes with GITHUB_TOKEN, which does not trigger the push event above, so


### PR DESCRIPTION
Follow-up to #132, which is now complete.

That PR made the deploy trigger accept `["master", "main"]` so the site would keep building either side of the default branch rename. The rename has since happened, and a deploy from `main` has run green, so the extra name has served its purpose.

```diff
-    branches: ["master", "main"]
+    branches: ["main"]
```

Back to naming the default branch once, as it did before.

## Note for anyone reading this later

The rename also needed a change that is not in either PR, because it lives in repository settings rather than the tree: the `github-pages` environment had a custom deployment branch policy allowing only `master`. Once `master` was gone, the build step still succeeded but `actions/deploy-pages` was rejected, with no failing step shown - the site simply stops updating. That policy now allows `main`.

## Testing

The deploy from `main` succeeded before this change, and this only narrows the trigger to the branch that is already deploying. Merging it exercises the trigger directly: if the site rebuilds from this merge, the trigger is right.